### PR TITLE
Feature/filename export alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,66 @@ Create a `.barrelize` file in your project root. The configuration file uses JSO
 }
 ```
 
+### Using Export Variables
+
+You can use variables in export aliases to dynamically name exports based on filenames or actual export names:
+
+```jsonc
+{
+  "barrels": [
+    {
+      "root": "src",
+      "name": "index.ts",
+      "include": ["components/**/*.tsx"],
+      "exports": {
+        "components/**/*.tsx": [
+          "default as $filename" // Use filename
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Supported Variables:**
+
+- `$filename` - The filename without extension (e.g., "Button" from "Button.tsx")
+- `$exportName` - The actual name of the default export from the code
+
+**Examples:**
+
+```typescript
+// components/button.tsx
+export default function ButtonComponent() {...}
+```
+
+Using `"default as $filename"`:
+
+```typescript
+export {default as button} from './components/button';
+```
+
+Using `"default as $exportName"`:
+
+```typescript
+export {default as ButtonComponent} from './components/button';
+```
+
+Using both in one pattern `"default as $filename$exportName"`:
+
+```typescript
+export {default as buttonButtonComponent} from './components/button';
+```
+
+**Notes:**
+
+- Works with nested directory paths (e.g., `utils/parsers/json.ts` → filename is `json`)
+- Preserves dots in filenames (e.g., `my.component.tsx` → `my.component`)
+- `$exportName` works with function, class, and variable default exports
+- For anonymous default exports (arrow functions without a name), `$exportName` falls back to the member name ("default")
+- Variables can be combined and used multiple times in the same alias
+- Works alongside other export patterns and with the `replace` config option
+
 ## Example
 
 Before:

--- a/schema.json
+++ b/schema.json
@@ -46,19 +46,13 @@
             {
               "root": "src",
               "name": "index.ts",
-              "include": [
-                "**/*.ts"
-              ],
-              "exclude": [
-                "**/*.test.ts"
-              ]
+              "include": ["**/*.ts"],
+              "exclude": ["**/*.test.ts"]
             }
           ]
         }
       },
-      "required": [
-        "barrels"
-      ],
+      "required": ["barrels"],
       "additionalProperties": false
     },
     "BarrelConfig": {
@@ -83,9 +77,7 @@
           },
           "description": "Files to include in the barrel (supports glob patterns)",
           "markdownDescription": "Files to include in the barrel (supports glob patterns)",
-          "default": [
-            "**/*.ts"
-          ]
+          "default": ["**/*.ts"]
         },
         "exclude": {
           "type": "array",
@@ -125,8 +117,8 @@
             "items": {
               "type": "string"
             },
-            "description": "Glob pattern exports file with string or regular expression patterns (e.g. \"**\\/*service.ts\": [\"* as lib\", \"/(.+)Config$/ as $1LibConfig\", \"util\"])",
-            "markdownDescription": "Glob pattern exports file with string or regular expression patterns\n(e.g. \"**\\/*service.ts\": [\"* as lib\", \"/(.+)Config$/ as $1LibConfig\", \"util\"])"
+            "description": "Glob pattern exports file with string or regular expression patterns. Supports variables: $filename (filename without extension) and $exportName (actual default export name). Example: \"**\\/*service.ts\": [\"* as lib\", \"/(.+)Config$/ as $1LibConfig\", \"default as $filename\", \"default as $exportName\"]",
+            "markdownDescription": "Glob pattern exports file with string or regular expression patterns\n\nSupports variables:\n- `$filename` - filename without extension\n- `$exportName` - actual default export name\n\nExample: `\"**\\/*service.ts\": [\"* as lib\", \"/(.+)Config$/ as $1LibConfig\", \"default as $filename\", \"default as $exportName\"]`"
           },
           "description": "Configuration for exports in barrel files",
           "markdownDescription": "Configuration for exports in barrel files",

--- a/test/barrel-generation.test.ts
+++ b/test/barrel-generation.test.ts
@@ -1,0 +1,333 @@
+import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'barrel-generation');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should create a basic barrel file', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'src', 'b.ts'), 'export const b = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexPath = join(testDir, 'src', 'index.ts');
+  expect(existsSync(indexPath)).toBe(true);
+
+  const indexContent = readFileSync(indexPath, 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+  expect(indexContent).toContain("export * from './b';");
+});
+
+test('should update existing barrel file', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'src', 'index.ts'), "export * from './old';");
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+  expect(indexContent).not.toContain("export * from './old';");
+});
+
+test('should handle include patterns', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'component.tsx'), 'export const Component = () => {};');
+  writeFileSync(join(testDir, 'src', 'util.ts'), 'export const util = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.tsx'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './component.tsx';");
+  expect(indexContent).not.toContain('util');
+});
+
+test('should handle exclude patterns', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'component.ts'), 'export const component = 1;');
+  writeFileSync(join(testDir, 'src', 'component.test.ts'), 'test("something", () => {});');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/*.test.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './component';");
+  expect(indexContent).not.toContain('test');
+});
+
+test('should handle multiple barrels', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+  mkdirSync(join(testDir, 'lib'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'lib', 'b.ts'), 'export const b = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+        {
+          root: 'lib',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const srcIndex = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(srcIndex).toContain("export * from './a';");
+
+  const libIndex = readFileSync(join(testDir, 'lib', 'index.ts'), 'utf-8');
+  expect(libIndex).toContain("export * from './b';");
+});
+
+test('should handle custom index file name', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'exports.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexPath = join(testDir, 'src', 'exports.ts');
+  expect(existsSync(indexPath)).toBe(true);
+
+  const indexContent = readFileSync(indexPath, 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+});
+
+test('should handle nested directory structure', async () => {
+  mkdirSync(join(testDir, 'src', 'components', 'forms'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'components', 'forms', 'input.ts'), 'export const Input = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './components/forms/input';");
+});
+
+test('should handle empty directory', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexPath = join(testDir, 'src', 'index.ts');
+  expect(existsSync(indexPath)).toBe(true);
+
+  const indexContent = readFileSync(indexPath, 'utf-8');
+  expect(indexContent.trim()).toBe('');
+});
+
+test('should handle no matching files', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.js'), 'export const a = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent.trim()).toBe('');
+});
+
+test('should exclude index file from exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'src', 'index.ts'), '');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+  expect(indexContent).not.toContain("export * from './index';");
+});
+
+test('should handle multiple include patterns', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'component.tsx'), 'export const Component = () => {};');
+  writeFileSync(join(testDir, 'src', 'util.ts'), 'export const util = 1;');
+  writeFileSync(join(testDir, 'src', 'styles.css'), '.class {}');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.tsx'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './component.tsx';");
+  expect(indexContent).toContain("export * from './util';");
+  expect(indexContent).not.toContain('styles');
+});
+
+test('should handle root at project level', async () => {
+  writeFileSync(join(testDir, 'a.ts'), 'export const a = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+});

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -1,0 +1,457 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'edge-cases');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should handle files with syntax errors gracefully', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'valid.ts'), 'export const valid = 1;');
+  writeFileSync(join(testDir, 'src', 'invalid.ts'), 'export const invalid = ;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './valid';");
+});
+
+test('should handle special characters in filenames', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'file-with-dash.ts'), 'export const foo = 1;');
+  writeFileSync(join(testDir, 'src', 'file_with_underscore.ts'), 'export const bar = 2;');
+  writeFileSync(join(testDir, 'src', 'file.with.dots.ts'), 'export const baz = 3;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './file-with-dash';");
+  expect(indexContent).toContain("export * from './file_with_underscore';");
+  expect(indexContent).toContain("export * from './file.with.dots';");
+});
+
+test('should handle unicode characters in filenames', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'файл.ts'), 'export const file = 1;');
+  writeFileSync(join(testDir, 'src', '文件.ts'), 'export const file2 = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('файл');
+  expect(indexContent).toContain('文件');
+});
+
+test('should handle empty files', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'empty.ts'), '');
+  writeFileSync(join(testDir, 'src', 'non-empty.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './empty';");
+  expect(indexContent).toContain("export * from './non-empty';");
+});
+
+test('should handle files with only comments', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'comments.ts'),
+    `// This is a comment
+/* Block comment */`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './comments';");
+});
+
+test('should handle mixed file extensions', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'typescript.ts'), 'export const ts = 1;');
+  writeFileSync(join(testDir, 'src', 'tsx.tsx'), 'export const tsx = 2;');
+  writeFileSync(join(testDir, 'src', 'javascript.js'), 'export const js = 3;');
+  writeFileSync(join(testDir, 'src', 'jsx.jsx'), 'export const jsx = 4;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('typescript');
+  expect(indexContent).toContain('tsx.tsx');
+  expect(indexContent).toContain('javascript.js');
+  expect(indexContent).toContain('jsx.jsx');
+});
+
+test('should handle very long file paths', async () => {
+  const deepPath = join(testDir, 'src', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h');
+  mkdirSync(deepPath, {recursive: true});
+
+  writeFileSync(join(deepPath, 'deep.ts'), 'export const deep = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './a/b/c/d/e/f/g/h/deep';");
+});
+
+test('should handle files with no exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'no-exports.ts'), 'const internal = 1;');
+  writeFileSync(join(testDir, 'src', 'with-exports.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './no-exports';");
+  expect(indexContent).toContain("export * from './with-exports';");
+});
+
+test('should handle overlapping glob patterns', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'component.tsx'), 'export const Component = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.tsx'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const occurrences = (indexContent.match(/component\.tsx/g) || []).length;
+  expect(occurrences).toBe(1);
+});
+
+test('should handle files that start with numbers', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', '01-first.ts'), 'export const first = 1;');
+  writeFileSync(join(testDir, 'src', '02-second.ts'), 'export const second = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './01-first';");
+  expect(indexContent).toContain("export * from './02-second';");
+});
+
+test('should handle files with uppercase extensions', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'file.TS'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.TS'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('file.TS');
+});
+
+test('should handle circular export prevention', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), "export * from './b';");
+  writeFileSync(join(testDir, 'src', 'b.ts'), "export * from './a';");
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+  expect(indexContent).toContain("export * from './b';");
+});
+
+test('should handle files with BOM', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'bom.ts'), '\uFEFFexport const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './bom';");
+});
+
+test('should handle different line endings', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'crlf.ts'), 'export const a = 1;\r\nexport const b = 2;');
+  writeFileSync(join(testDir, 'src', 'lf.ts'), 'export const c = 3;\nexport const d = 4;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './crlf';");
+  expect(indexContent).toContain("export * from './lf';");
+});
+
+test('should handle export with same name as file', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'Button.ts'), 'export const Button = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['Button'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { Button } from './Button';");
+});
+
+test('should handle default export with no name', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'component.ts'), 'export default () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['default'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { default } from './component';");
+});
+
+test('should handle re-exports from other modules', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'reexport.ts'), "export { foo } from 'external';");
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './reexport';");
+});

--- a/test/exports-config.test.ts
+++ b/test/exports-config.test.ts
@@ -1,0 +1,440 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'exports-config');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should handle wildcard exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'utils.ts'),
+    `export const foo = 1;
+export const bar = 2;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['*'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './utils';");
+});
+
+test('should handle named exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'utils.ts'),
+    `export const foo = 1;
+export const bar = 2;
+export const baz = 3;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['foo', 'bar'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { foo, bar } from './utils';");
+  expect(indexContent).not.toContain('baz');
+});
+
+test('should handle default exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'component.ts'), 'export default function Component() {}');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['default'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { default } from './component';");
+});
+
+test('should handle namespace exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'utils.ts'),
+    `export const foo = 1;
+export const bar = 2;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['* as utils'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * as utils from './utils';");
+});
+
+test('should handle wildcard exports by default when exports array exists', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'component.ts'),
+    `export const ButtonConfig = { size: 'large' };
+export const InputConfig = { type: 'text' };
+export const helper = () => {};`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './component';");
+});
+
+test('should handle specific named exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'component.ts'),
+    `export const ButtonConfig = { size: 'large' };
+export const InputConfig = { type: 'text' };`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['ButtonConfig', 'InputConfig'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('ButtonConfig');
+  expect(indexContent).toContain('InputConfig');
+});
+
+test('should handle multiple export patterns per file', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'utils.ts'),
+    `export const foo = 1;
+export const bar = 2;
+export default function defaultFn() {}`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['foo', 'default'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { foo, default } from './utils';");
+  expect(indexContent).not.toContain('bar');
+});
+
+test('should handle type exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'types.ts'),
+    `export type User = { name: string };
+export const value = 1;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['User'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('type User');
+});
+
+test('should mix wildcard and named exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'a.ts'),
+    `export const foo = 1;
+export const bar = 2;`,
+  );
+
+  writeFileSync(join(testDir, 'src', 'b.ts'), `export const baz = 3;`);
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            'a.ts': ['foo'],
+            'b.ts': ['*'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { foo } from './a';");
+  expect(indexContent).toContain("export * from './b';");
+});
+
+test('should handle renamed exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), `export const foo = 1;`);
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['foo as bar'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { foo as bar } from './utils';");
+});
+
+test('should handle exports from different file patterns', async () => {
+  mkdirSync(join(testDir, 'src', 'components'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'utils'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'components', 'button.ts'), 'export default function Button() {}');
+
+  writeFileSync(join(testDir, 'src', 'utils', 'format.ts'), 'export const format = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            'components/**/*.ts': ['default'],
+            'utils/**/*.ts': ['*'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { default } from './components/button';");
+  expect(indexContent).toContain("export * from './utils/format';");
+});
+
+test('should handle empty exports array', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': [],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './utils';");
+});
+
+test('should include non-existent exports as-is', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['nonExistent'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('nonExistent');
+});
+
+test('should handle namespace with rename', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'helpers.ts'),
+    `export const a = 1;
+export const b = 2;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['* as helperLib'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * as helperLib from './helpers';");
+});

--- a/test/filename-variable.test.ts
+++ b/test/filename-variable.test.ts
@@ -1,0 +1,431 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'filename-var');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should substitute $filename in export aliases for default exports', async () => {
+  mkdirSync(join(testDir, 'services'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'services', 'auth.ts'),
+    'export default function authenticate() { return true; }',
+  );
+
+  writeFileSync(
+    join(testDir, 'services', 'database.ts'),
+    'export default function connect() { return true; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['services/**/*.ts'],
+          exports: {
+            'services/**/*.ts': ['default as $filename'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as auth } from './services/auth';");
+  expect(indexContent).toContain("export { default as database } from './services/database';");
+});
+
+test('should work with nested directory structures', async () => {
+  mkdirSync(join(testDir, 'utils', 'parsers'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'utils', 'parsers', 'json.ts'),
+    'export default function parseJson() { return {}; }',
+  );
+
+  writeFileSync(
+    join(testDir, 'utils', 'parsers', 'xml.ts'),
+    'export default function parseXml() { return {}; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['utils/**/*.ts'],
+          exports: {
+            'utils/**/*.ts': ['default as $filename'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as json } from './utils/parsers/json';");
+  expect(indexContent).toContain("export { default as xml } from './utils/parsers/xml';");
+});
+
+test('should handle files with dots in filename', async () => {
+  mkdirSync(join(testDir, 'helpers'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'helpers', 'my.helper.ts'),
+    'export default function myHelper() { return true; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['helpers/**/*.ts'],
+          exports: {
+            'helpers/**/*.ts': ['default as $filename'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as my.helper } from './helpers/my.helper';");
+});
+
+test('should support multiple $filename substitutions in one alias', async () => {
+  mkdirSync(join(testDir, 'validators'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'validators', 'email.ts'),
+    'export default function validateEmail() { return true; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['validators/**/*.ts'],
+          exports: {
+            'validators/**/*.ts': ['default as $filename$filename'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as emailemail } from './validators/email';");
+});
+
+test('should work alongside other export patterns', async () => {
+  mkdirSync(join(testDir, 'utils'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'utils', 'format.ts'),
+    `export default function formatDefault() { return 'default'; }
+export const formatDate = () => 'date';
+export const formatTime = () => 'time';`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['utils/**/*.ts'],
+          exports: {
+            'utils/**/*.ts': ['default as $filename', 'formatDate'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as format, formatDate } from './utils/format';");
+});
+
+test('should preserve filename casing', async () => {
+  mkdirSync(join(testDir, 'services'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'services', 'CacheManager.ts'),
+    'export default function cacheManager() { return {}; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['services/**/*.ts'],
+          exports: {
+            'services/**/*.ts': ['default as $filename'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as CacheManager } from './services/CacheManager';");
+});
+
+test('should work with replace config option', async () => {
+  mkdirSync(join(testDir, 'handlers'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'handlers', 'request.handler.ts'),
+    'export default function handleRequest() { return true; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['handlers/**/*.ts'],
+          replace: {
+            '/\\.handler\\.ts$/': '',
+          },
+          exports: {
+            'handlers/**/*.ts': ['default as $filename'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as request.handler } from './handlers/request';");
+});
+
+test('should substitute $exportName with actual export name', async () => {
+  mkdirSync(join(testDir, 'services'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'services', 'login.ts'),
+    'export default function LoginService() { return true; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['services/**/*.ts'],
+          exports: {
+            'services/**/*.ts': ['default as $exportName'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as LoginService } from './services/login';");
+});
+
+test('should handle $exportName when export name differs from filename', async () => {
+  mkdirSync(join(testDir, 'parsers'), {recursive: true});
+
+  writeFileSync(join(testDir, 'parsers', 'data.ts'), 'export default function JsonParser() { return {}; }');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['parsers/**/*.ts'],
+          exports: {
+            'parsers/**/*.ts': ['default as $exportName'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as JsonParser } from './parsers/data';");
+});
+
+test('should fallback to member name for anonymous default exports with $exportName', async () => {
+  mkdirSync(join(testDir, 'utils'), {recursive: true});
+
+  writeFileSync(join(testDir, 'utils', 'helper.ts'), 'export default () => { return null; }');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['utils/**/*.ts'],
+          exports: {
+            'utils/**/*.ts': ['default as $exportName'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default } from './utils/helper';");
+});
+
+test('should support both $filename and $exportName in same config', async () => {
+  mkdirSync(join(testDir, 'services'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'services', 'storage.ts'),
+    'export default function StorageService() { return true; }',
+  );
+
+  writeFileSync(
+    join(testDir, 'services', 'state.ts'),
+    'export default function StateManager() { return {}; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['services/**/*.ts'],
+          exports: {
+            'services/**/*.ts': ['default as $exportName'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as StorageService } from './services/storage';");
+  expect(indexContent).toContain("export { default as StateManager } from './services/state';");
+});
+
+test('should use both variables in same alias pattern', async () => {
+  mkdirSync(join(testDir, 'handlers'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'handlers', 'request.ts'),
+    'export default function RequestHandler() { return true; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['handlers/**/*.ts'],
+          exports: {
+            'handlers/**/*.ts': ['default as $filename$exportName'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as requestRequestHandler } from './handlers/request';");
+});
+
+test('should work with class default exports using $exportName', async () => {
+  mkdirSync(join(testDir, 'services'), {recursive: true});
+
+  writeFileSync(join(testDir, 'services', 'api.ts'), 'export default class ApiService { constructor() {} }');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: '.',
+          name: 'index.ts',
+          include: ['services/**/*.ts'],
+          exports: {
+            'services/**/*.ts': ['default as $exportName'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'index.ts'), 'utf-8');
+
+  expect(indexContent).toContain("export { default as ApiService } from './services/api';");
+});

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -1,0 +1,439 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'formatting');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should use bracket spacing by default', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['foo'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('export { foo } from');
+});
+
+test('should disable bracket spacing', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      bracketSpacing: false,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['foo'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('export {foo} from');
+});
+
+test('should use single quotes by default', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("from './utils'");
+});
+
+test('should use double quotes', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      singleQuote: false,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('from "./utils"');
+});
+
+test('should use semicolons by default', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("from './utils';");
+});
+
+test('should disable semicolons', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      semi: false,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).not.toContain(';');
+  expect(indexContent).toContain("from './utils'");
+});
+
+test('should add final newline by default', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent.endsWith('\n')).toBe(true);
+});
+
+test('should disable final newline', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      insertFinalNewline: false,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent.endsWith('\n')).toBe(false);
+});
+
+test('should override global formatting per barrel', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+  mkdirSync(join(testDir, 'lib'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+  writeFileSync(join(testDir, 'lib', 'helper.ts'), 'export const bar = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      singleQuote: true,
+      semi: true,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+        {
+          root: 'lib',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          singleQuote: false,
+          semi: false,
+        },
+      ],
+    },
+    true,
+  );
+
+  const srcContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(srcContent).toContain("from './utils';");
+
+  const libContent = readFileSync(join(testDir, 'lib', 'index.ts'), 'utf-8');
+  expect(libContent).toContain('from "./helper"');
+  expect(libContent).not.toContain(';');
+});
+
+test('should combine all formatting options', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      bracketSpacing: false,
+      singleQuote: false,
+      semi: false,
+      insertFinalNewline: false,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['foo'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toBe('export {foo} from "./utils"');
+});
+
+test('should apply formatting to named exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'utils.ts'),
+    `export const foo = 1;
+export const bar = 2;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      bracketSpacing: true,
+      singleQuote: true,
+      semi: true,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['foo', 'bar'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { foo, bar } from './utils';");
+});
+
+test('should apply formatting to wildcard exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      singleQuote: false,
+      semi: false,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('export * from "./utils"');
+});
+
+test('should apply formatting to namespace exports', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      singleQuote: false,
+      semi: true,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['* as utils'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('export * as utils from "./utils";');
+});
+
+test('should handle barrel-specific bracket spacing', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const foo = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          bracketSpacing: false,
+          exports: {
+            '**/*.ts': ['foo'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('export {foo} from');
+});
+
+test('should handle multiple exports with formatting', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'utils.ts'),
+    `export const a = 1;
+export const b = 2;
+export const c = 3;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      bracketSpacing: true,
+      singleQuote: true,
+      semi: true,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            '**/*.ts': ['a', 'b', 'c'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export { a, b, c } from './utils';");
+});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,456 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'integration');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should handle complete workflow with real-world structure', async () => {
+  mkdirSync(join(testDir, 'src', 'components'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'utils'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'types'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'components', 'Button.tsx'),
+    'export default function Button() { return null; }',
+  );
+  writeFileSync(
+    join(testDir, 'src', 'components', 'Input.tsx'),
+    'export default function Input() { return null; }',
+  );
+  writeFileSync(join(testDir, 'src', 'utils', 'format.ts'), 'export const format = () => {};');
+  writeFileSync(join(testDir, 'src', 'types', 'user.ts'), 'export type User = { name: string };');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.tsx'],
+          exclude: ['**/*.test.ts'],
+          order: ['types', 'utils', 'components'],
+          replace: {
+            '/\\.tsx?$/': '',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('types/user');
+  expect(lines[1]).toContain('utils/format');
+  expect(lines[2]).toContain('components/Button');
+  expect(lines[3]).toContain('components/Input');
+});
+
+test('should update existing barrel file without markers', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'src', 'index.ts'), "export * from './old';\n");
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+  expect(indexContent).not.toContain('old');
+});
+
+test('should handle barrelize-start and barrelize-end markers', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(
+    join(testDir, 'src', 'index.ts'),
+    `// Custom code before
+// barrelize-start
+export * from './old';
+// barrelize-end
+// Custom code after`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('// Custom code before');
+  expect(indexContent).toContain('// Custom code after');
+  expect(indexContent).toContain("export * from './a';");
+  expect(indexContent).not.toContain('old');
+});
+
+test('should be idempotent on multiple runs', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const firstRun = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const secondRun = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+
+  expect(firstRun).toBe(secondRun);
+});
+
+test('should handle complex multi-barrel configuration', async () => {
+  mkdirSync(join(testDir, 'src', 'api'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'components'), {recursive: true});
+  mkdirSync(join(testDir, 'lib'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'api', 'client.ts'), 'export const client = {};');
+  writeFileSync(join(testDir, 'src', 'components', 'Button.tsx'), 'export default function Button() {}');
+  writeFileSync(join(testDir, 'lib', 'utils.ts'), 'export const utils = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      singleQuote: true,
+      semi: true,
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.tsx'],
+          replace: {
+            '/\\.tsx?$/': '',
+          },
+        },
+        {
+          root: 'lib',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          singleQuote: false,
+          semi: false,
+        },
+      ],
+    },
+    true,
+  );
+
+  const srcIndex = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(srcIndex).toContain("from './api/client';");
+
+  const libIndex = readFileSync(join(testDir, 'lib', 'index.ts'), 'utf-8');
+  expect(libIndex).toContain('from "./utils"');
+  expect(libIndex).not.toContain(';');
+});
+
+test('should handle real-world exports configuration', async () => {
+  mkdirSync(join(testDir, 'src', 'services'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'hooks'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'services', 'auth.ts'),
+    `export const AuthConfig = {};
+export const authService = {};`,
+  );
+
+  writeFileSync(
+    join(testDir, 'src', 'hooks', 'useAuth.ts'),
+    'export default function useAuth() { return null; }',
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/\\.ts$/': '',
+          },
+          exports: {
+            'services/**/*.ts': ['/(.+)Config$/ as $1Settings'],
+            'hooks/**/*.ts': ['default as $filename'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('AuthConfig as AuthSettings');
+  expect(indexContent).toContain('default as useAuth');
+});
+
+test('should handle incremental updates', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'src', 'b.ts'), 'export const b = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const firstContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(firstContent).toContain("export * from './a';");
+  expect(firstContent).toContain("export * from './b';");
+
+  writeFileSync(join(testDir, 'src', 'c.ts'), 'export const c = 3;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const secondContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(secondContent).toContain("export * from './a';");
+  expect(secondContent).toContain("export * from './b';");
+  expect(secondContent).toContain("export * from './c';");
+});
+
+test('should handle file removal updates', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'src', 'b.ts'), 'export const b = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  rmSync(join(testDir, 'src', 'b.ts'));
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const content = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(content).toContain("export * from './a';");
+  expect(content).not.toContain("export * from './b';");
+});
+
+test('should handle complex project structure', async () => {
+  mkdirSync(join(testDir, 'src', 'features', 'auth', 'components'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'features', 'auth', 'services'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'shared', 'utils'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'features', 'auth', 'components', 'LoginForm.tsx'),
+    'export default function LoginForm() {}',
+  );
+  writeFileSync(
+    join(testDir, 'src', 'features', 'auth', 'services', 'authService.ts'),
+    'export const authService = {};',
+  );
+  writeFileSync(join(testDir, 'src', 'shared', 'utils', 'format.ts'), 'export const format = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.tsx'],
+          order: ['shared', 'features'],
+          replace: {
+            '/\\.tsx?$/': '',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('shared/utils/format');
+  expect(indexContent).toContain('features/auth/components/LoginForm');
+  expect(indexContent).toContain('features/auth/services/authService');
+});
+
+test('should handle mixed exports in single barrel', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'mixed.ts'),
+    `export const namedExport = 1;
+export default function defaultExport() {}
+export type TypeExport = string;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exclude: ['**/index.ts'],
+          exports: {
+            '**/*.ts': ['namedExport', 'default', 'TypeExport'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('namedExport');
+  expect(indexContent).toContain('default');
+  expect(indexContent).toContain('type TypeExport');
+});
+
+test('should handle namespace and named exports together', async () => {
+  mkdirSync(join(testDir, 'src', 'utils'), {recursive: true});
+
+  writeFileSync(
+    join(testDir, 'src', 'utils', 'helpers.ts'),
+    `export const helper1 = 1;
+export const helper2 = 2;`,
+  );
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          exports: {
+            'utils/**/*.ts': ['* as helpers', 'helper1'],
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain('export * as helpers from');
+  expect(indexContent).toContain('export { helper1 } from');
+});

--- a/test/ordering.test.ts
+++ b/test/ordering.test.ts
@@ -1,0 +1,357 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'ordering');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should order exports alphabetically by default', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'zebra.ts'), 'export const zebra = 1;');
+  writeFileSync(join(testDir, 'src', 'alpha.ts'), 'export const alpha = 1;');
+  writeFileSync(join(testDir, 'src', 'beta.ts'), 'export const beta = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('alpha');
+  expect(lines[1]).toContain('beta');
+  expect(lines[2]).toContain('zebra');
+});
+
+test('should order exports based on custom order', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'types.ts'), 'export type User = {};');
+  writeFileSync(join(testDir, 'src', 'constants.ts'), 'export const MAX = 100;');
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const util = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: ['types', 'constants', 'utils'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('types');
+  expect(lines[1]).toContain('constants');
+  expect(lines[2]).toContain('utils');
+});
+
+test('should place ordered files first, then alphabetically', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'types.ts'), 'export type User = {};');
+  writeFileSync(join(testDir, 'src', 'zebra.ts'), 'export const zebra = 1;');
+  writeFileSync(join(testDir, 'src', 'alpha.ts'), 'export const alpha = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: ['types'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('types');
+  expect(lines[1]).toContain('alpha');
+  expect(lines[2]).toContain('zebra');
+});
+
+test('should handle nested path ordering', async () => {
+  mkdirSync(join(testDir, 'src', 'components'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'utils'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'components', 'button.ts'), 'export const Button = () => {};');
+  writeFileSync(join(testDir, 'src', 'utils', 'format.ts'), 'export const format = () => {};');
+  writeFileSync(join(testDir, 'src', 'types.ts'), 'export type User = {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: ['types', 'components', 'utils'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('types');
+  expect(lines[1]).toContain('components/button');
+  expect(lines[2]).toContain('utils/format');
+});
+
+test('should order alphabetically by default', async () => {
+  mkdirSync(join(testDir, 'src', 'components', 'forms'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'components', 'forms', 'input.ts'), 'export const Input = () => {};');
+  writeFileSync(join(testDir, 'src', 'components', 'button.ts'), 'export const Button = () => {};');
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const utils = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('components/button');
+  expect(lines[1]).toContain('components/forms/input');
+  expect(lines[2]).toContain('utils');
+});
+
+test('should handle partial order matches', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'types.core.ts'), 'export type Core = {};');
+  writeFileSync(join(testDir, 'src', 'types.user.ts'), 'export type User = {};');
+  writeFileSync(join(testDir, 'src', 'constants.ts'), 'export const MAX = 100;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: ['types'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('types.core');
+  expect(lines[1]).toContain('types.user');
+  expect(lines[2]).toContain('constants');
+});
+
+test('should maintain alphabetical order within same order group', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'types.zebra.ts'), 'export type Zebra = {};');
+  writeFileSync(join(testDir, 'src', 'types.alpha.ts'), 'export type Alpha = {};');
+  writeFileSync(join(testDir, 'src', 'types.beta.ts'), 'export type Beta = {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: ['types'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('types.alpha');
+  expect(lines[1]).toContain('types.beta');
+  expect(lines[2]).toContain('types.zebra');
+});
+
+test('should handle order with nested directories', async () => {
+  mkdirSync(join(testDir, 'src', 'components', 'ui'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'utils'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'components', 'ui', 'button.ts'), 'export const Button = () => {};');
+  writeFileSync(join(testDir, 'src', 'utils', 'format.ts'), 'export const format = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: ['utils', 'components'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('utils/format');
+  expect(lines[1]).toContain('components/ui/button');
+});
+
+test('should handle empty order array', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'zebra.ts'), 'export const zebra = 1;');
+  writeFileSync(join(testDir, 'src', 'alpha.ts'), 'export const alpha = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: [],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('alpha');
+  expect(lines[1]).toContain('zebra');
+});
+
+test('should handle order with file extensions', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'index.css'), '.class {}');
+  writeFileSync(join(testDir, 'src', 'component.tsx'), 'export const Component = () => {};');
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const utils = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts', '**/*.tsx'],
+          order: ['component', 'utils'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('component.tsx');
+  expect(lines[1]).toContain('utils');
+});
+
+test('should handle complex ordering scenario', async () => {
+  mkdirSync(join(testDir, 'src', 'api'), {recursive: true});
+  mkdirSync(join(testDir, 'src', 'components'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'types.ts'), 'export type T = {};');
+  writeFileSync(join(testDir, 'src', 'constants.ts'), 'export const C = 1;');
+  writeFileSync(join(testDir, 'src', 'api', 'client.ts'), 'export const client = {};');
+  writeFileSync(join(testDir, 'src', 'components', 'button.ts'), 'export const Button = () => {};');
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const utils = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          order: ['types', 'constants', 'api'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  const lines = indexContent.split('\n').filter((l) => l.trim());
+
+  expect(lines[0]).toContain('types');
+  expect(lines[1]).toContain('constants');
+  expect(lines[2]).toContain('api/client');
+  const hasComponents = indexContent.includes('components/button');
+  const hasUtils = indexContent.includes('utils');
+  expect(hasComponents).toBe(true);
+  expect(hasUtils).toBe(true);
+});

--- a/test/path-replace.test.ts
+++ b/test/path-replace.test.ts
@@ -1,0 +1,373 @@
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import {generateBarrels} from '../src/generate/generate-barrels';
+
+const testDir = join(__dirname, 'test-fixtures', 'path-replace');
+
+beforeEach(() => {
+  mkdirSync(testDir, {recursive: true});
+});
+
+afterEach(() => {
+  rmSync(testDir, {recursive: true, force: true});
+});
+
+test('should replace file extension with regex', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.jsx'), 'export const util = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.jsx'],
+          replace: {
+            '/\\.jsx$/': '',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './utils';");
+  expect(indexContent).not.toContain('.jsx');
+});
+
+test('should replace with regex pattern', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'component.tsx'), 'export const Component = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.tsx'],
+          replace: {
+            '/\\.tsx$/': '',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './component';");
+  expect(indexContent).not.toContain('.tsx');
+});
+
+test('should apply only first matching replacement rule', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'MyComponent.tsx'), 'export const MyComponent = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.tsx'],
+          replace: {
+            '/^My(.+)\\.tsx$/': '$1',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './Component';");
+});
+
+test('should use regex capture groups', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'button.component.ts'), 'export const ButtonComponent = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/(.+)\\.component\\.ts$/': '$1',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './button';");
+  expect(indexContent).not.toContain('component');
+});
+
+test('should apply default replace when no custom replace specified', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'utils.ts'), 'export const util = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './utils';");
+});
+
+test('should handle empty replacement', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'prefix-utils.ts'), 'export const util = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/^prefix-(.+)\\.ts$/': '$1',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './utils';");
+  expect(indexContent).not.toContain('prefix');
+});
+
+test('should replace in nested paths', async () => {
+  mkdirSync(join(testDir, 'src', 'components'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'components', 'button.component.ts'), 'export const Button = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/\\.component\\.ts$/': '',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './components/button';");
+});
+
+test('should handle complex regex patterns', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'use-auth-hook.ts'), 'export const useAuth = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/^use-(.+)-hook\\.ts$/': '$1',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './auth';");
+});
+
+test('should handle multiple files with same replacement', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'a.spec.ts'), 'export const a = 1;');
+  writeFileSync(join(testDir, 'src', 'b.spec.ts'), 'export const b = 2;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/\\.spec\\.ts$/': '',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './a';");
+  expect(indexContent).toContain("export * from './b';");
+  expect(indexContent).not.toContain('spec');
+});
+
+test('should replace directory names in path', async () => {
+  mkdirSync(join(testDir, 'src', '__tests__'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', '__tests__', 'utils.ts'), 'export const util = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/__tests__\\/(.+)\\.ts$/': 'tests/$1',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './tests/utils';");
+  expect(indexContent).not.toContain('__tests__');
+});
+
+test('should handle case-sensitive replacement', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'Component.ts'), 'export const Component = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/Component\\.ts$/': 'component',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './component';");
+});
+
+test('should handle case-insensitive replacement with flag', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'MyComponent.ts'), 'export const MyComponent = () => {};');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/component\\.ts$/i': 'comp',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './Mycomp';");
+});
+
+test('should handle regex path replacement with substitution', async () => {
+  mkdirSync(join(testDir, 'src'), {recursive: true});
+
+  writeFileSync(join(testDir, 'src', 'special.ts'), 'export const special = 1;');
+  writeFileSync(join(testDir, 'src', 'regular.ts'), 'export const regular = 1;');
+
+  await generateBarrels(
+    testDir,
+    '.barrelize',
+    {
+      barrels: [
+        {
+          root: 'src',
+          name: 'index.ts',
+          include: ['**/*.ts'],
+          replace: {
+            '/^(special)\\.ts$/': 'custom-name',
+            '/^(regular)\\.ts$/': '$1',
+          },
+        },
+      ],
+    },
+    true,
+  );
+
+  const indexContent = readFileSync(join(testDir, 'src', 'index.ts'), 'utf-8');
+  expect(indexContent).toContain("export * from './custom-name';");
+  expect(indexContent).toContain("export * from './regular';");
+});

--- a/test/regex-parsing.test.ts
+++ b/test/regex-parsing.test.ts
@@ -1,0 +1,208 @@
+import {expect, test} from 'vitest';
+import {tryParseRegex} from '../src/regex/try-parse-regex';
+
+test('should parse valid regex pattern', () => {
+  const result = tryParseRegex('/test/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.source).toBe('test');
+});
+
+test('should parse regex with flags', () => {
+  const result = tryParseRegex('/test/gi');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toBe('gi');
+});
+
+test('should parse complex regex pattern', () => {
+  const result = tryParseRegex('/(.+)Config$/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.source).toBe('(.+)Config$');
+});
+
+test('should return null for non-regex string', () => {
+  const result = tryParseRegex('test');
+  expect(result).toBeNull();
+});
+
+test('should return null for string not starting with slash', () => {
+  const result = tryParseRegex('test/gi');
+  expect(result).toBeNull();
+});
+
+test('should return null for string with no ending slash', () => {
+  const result = tryParseRegex('/test');
+  expect(result).toBeNull();
+});
+
+test('should handle empty pattern', () => {
+  const result = tryParseRegex('//');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.source).toBe('(?:)');
+});
+
+test('should handle common valid flags', () => {
+  const result = tryParseRegex('/test/gim');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toBe('gim');
+});
+
+test('should return null for invalid flags', () => {
+  const result = tryParseRegex('/test/x');
+  expect(result).toBeNull();
+});
+
+test('should handle case-insensitive flag', () => {
+  const result = tryParseRegex('/test/i');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('TEST')).toBe(true);
+});
+
+test('should handle global flag', () => {
+  const result = tryParseRegex('/test/g');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toContain('g');
+});
+
+test('should handle multiline flag', () => {
+  const result = tryParseRegex('/test/m');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toContain('m');
+});
+
+test('should handle special characters in pattern', () => {
+  const result = tryParseRegex('/\\d+/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('123')).toBe(true);
+});
+
+test('should handle escape sequences', () => {
+  const result = tryParseRegex('/\\./');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('.')).toBe(true);
+  expect(result?.test('a')).toBe(false);
+});
+
+test('should handle character classes', () => {
+  const result = tryParseRegex('/[abc]/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('a')).toBe(true);
+  expect(result?.test('d')).toBe(false);
+});
+
+test('should handle quantifiers', () => {
+  const result = tryParseRegex('/a+/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('aaa')).toBe(true);
+});
+
+test('should handle capture groups', () => {
+  const result = tryParseRegex('/(.+)Config$/');
+  expect(result).toBeInstanceOf(RegExp);
+  const match = 'ButtonConfig'.match(result!);
+  expect(match?.[1]).toBe('Button');
+});
+
+test('should handle non-capturing groups', () => {
+  const result = tryParseRegex('/(?:test)/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('test')).toBe(true);
+});
+
+test('should handle lookaheads', () => {
+  const result = tryParseRegex('/test(?=ing)/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('testing')).toBe(true);
+  expect(result?.test('test')).toBe(false);
+});
+
+test('should handle lookbehinds', () => {
+  const result = tryParseRegex('/(?<=pre)test/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('pretest')).toBe(true);
+});
+
+test('should handle alternation', () => {
+  const result = tryParseRegex('/foo|bar/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('foo')).toBe(true);
+  expect(result?.test('bar')).toBe(true);
+});
+
+test('should handle anchors', () => {
+  const result = tryParseRegex('/^test$/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('test')).toBe(true);
+  expect(result?.test('testing')).toBe(false);
+});
+
+test('should handle word boundaries', () => {
+  const result = tryParseRegex('/\\btest\\b/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('test')).toBe(true);
+  expect(result?.test('testing')).toBe(false);
+});
+
+test('should return null for invalid regex pattern', () => {
+  const result = tryParseRegex('/(/');
+  expect(result).toBeNull();
+});
+
+test('should handle slash in pattern', () => {
+  const result = tryParseRegex('/\\/path\\/to\\/file/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('/path/to/file')).toBe(true);
+});
+
+test('should handle multiple slashes in pattern', () => {
+  const result = tryParseRegex('/a\\/b\\/c/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.source).toBe('a\\/b\\/c');
+});
+
+test('should use last slash as delimiter', () => {
+  const result = tryParseRegex('/test\\/pattern/i');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.source).toBe('test\\/pattern');
+  expect(result?.flags).toBe('i');
+});
+
+test('should handle unicode flag', () => {
+  const result = tryParseRegex('/test/u');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toContain('u');
+});
+
+test('should handle sticky flag', () => {
+  const result = tryParseRegex('/test/y');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toContain('y');
+});
+
+test('should handle dotall flag', () => {
+  const result = tryParseRegex('/test/s');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toContain('s');
+});
+
+test('should handle combined flags in any order', () => {
+  const result = tryParseRegex('/test/igm');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.flags).toContain('i');
+  expect(result?.flags).toContain('g');
+  expect(result?.flags).toContain('m');
+});
+
+test('should handle regex for file extensions', () => {
+  const result = tryParseRegex('/\\.tsx?$/');
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result?.test('file.ts')).toBe(true);
+  expect(result?.test('file.tsx')).toBe(true);
+  expect(result?.test('file.js')).toBe(false);
+});
+
+test('should handle regex for path replacement', () => {
+  const result = tryParseRegex('/(.+)\\.component\\.ts$/');
+  expect(result).toBeInstanceOf(RegExp);
+  const match = 'button.component.ts'.match(result!);
+  expect(match?.[1]).toBe('button');
+});


### PR DESCRIPTION
## Description

This PR adds support for dynamic export variable substitution in barrel file generation. Users can now use `$filename` and `$exportName` variables in export alias patterns to automatically name exports based on the file name or the actual export name in the code.

**Key features:**
- `$filename` - Uses the filename without extension (e.g., "button" from "button.tsx")
- `$exportName` - Uses the actual name of the default export from the source code
- Variables can be combined and used multiple times in the same alias pattern
- Works alongside existing export patterns and with the `replace` config option

**Example usage:**
```jsonc
{
  "exports": {
    "components/**/*.tsx": ["default as $filename"]
  }
}
```

Generates:
```typescript
export { default as button } from './components/button';
export { default as input } from './components/input';
```

**Implementation:**
- Modified export extraction logic to capture actual export names
- Enhanced export alias handling to support variable substitution
- Added comprehensive test suite covering barrel generation, edge cases, filename variables, formatting, integration, ordering, path replacement, and regex parsing (9 test files, ~3,200 lines of tests)
- Updated documentation with detailed examples and use cases
- Enhanced JSON schema with variable documentation

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes